### PR TITLE
feat+fix: add depends_on to docker-compose file + visual tweaks

### DIFF
--- a/backend/src/routes/counter.py
+++ b/backend/src/routes/counter.py
@@ -10,8 +10,7 @@ import datetime
 
 blueprint = Blueprint('counter', __name__)
 
-RESPONSE_TEMPLATE = 'Flask server running on port 8080. Pinged {count} {times}, \
-most recently on {date}.'
+RESPONSE_TEMPLATE = '{count} {times}'
 
 
 @blueprint.route('/')
@@ -36,6 +35,5 @@ def api():
     times = 'time' if counter.count == 1 else 'times'
     response = RESPONSE_TEMPLATE.format(
         count=counter.count,
-        times=times,
-        date=dateStr)
+        times=times)
     return jsonify(response=response)

--- a/cypress/e2e/first-test.cy.js
+++ b/cypress/e2e/first-test.cy.js
@@ -1,51 +1,31 @@
 describe("shipyard flask react example app", () => {
   beforeEach(() => {
-    // Cypress starts out with a blank slate for each test
-    // so we must tell it to visit our website with the `cy.visit()` command.
-    // Since we want to visit the same URL at the start of all our tests,
-    // we include it in our beforeEach function so that it runs before each test
-    const urlToVisit = "/" + "?shipyard_token=" + Cypress.env("BYPASS_TOKEN");
-    cy.visit(urlToVisit);
+    const pathWithShipyardToken = path => {
+      return path + "?shipyard_token=" + Cypress.env("BYPASS_TOKEN");
+    };
+    cy.visit(pathWithShipyardToken("/"));
   });
 
   it("Displays the logo with correct alt text", () => {
-    cy.get(".makeStyles-img-4")
-      .first()
-      .should("have.attr", "alt", "Shipyard logo");
+    cy.get("#page-logo").should("have.attr", "alt", "Shipyard logo");
   });
 
   it("Counter should be larger than 1000", () => {
-    // TBD outline
-    // - Run the test. It succeeds
-    //
-    // - Visits the page manually, click reset counter
-    // - Go to GitHub Pull Request action
-    // - Re-run the test, it fails
-    // - Go to data dashboard
-    // - Roll back the database to a known good state
-    // - Re-run the test, it should succeed
-
-    cy.get("p")
-      .contains("Flask server running on port")
-      .then($countInfo => {
-        const count = parseInt(
-          $countInfo.text().match(/Pinged (\d+) time/)?.[1],
-          10
-        );
-        expect(count).to.be.greaterThan(1000);
-      });
+    cy.get("#api-call-counter").then($countInfo => {
+      const count = parseInt($countInfo.text().match(/(\d+) time/)?.[1], 10);
+      expect(count).to.be.greaterThan(1000);
+    });
   });
 
   it("Reset Button", () => {
-    cy.get("button")
+    cy.get("#api-call-reset-button")
       .contains("Reset Counter")
       .click();
-  
+
     cy.wait(1000);
-  
+
     cy.get("p")
       .contains("Flask server running on port")
       .should("contain", "1 time");
   });
-  
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - './frontend/public:/app/public'
     ports:
       - '3000:3000'
+    depends_on:
+      - backend
 
   backend:
     labels:
@@ -32,6 +34,10 @@ services:
       - './backend/src:/srv/src:ro'
     ports:
       - '8080:8080'
+    depends_on:
+      - postgres
+      - redis
+      - localstack
 
   worker:
     labels:
@@ -47,6 +53,8 @@ services:
       - './backend/filesystem/entrypoints:/entrypoints:ro'
       - './backend/migrations:/srv/migrations'
       - './backend/src:/srv/src:ro'
+    depends_on:
+      - postgres
 
   postgres:
     image: 'postgres:9.6-alpine'

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -1,91 +1,91 @@
-import Prism from 'prismjs';
-import 'prismjs/themes/prism-tomorrow.css';
-import { Grid, Box, Link, Typography } from '@material-ui/core';
+import Prism from "prismjs";
+import "prismjs/themes/prism-tomorrow.css";
+import { Grid, Box, Link, Typography } from "@material-ui/core";
 import {
   makeStyles,
   createMuiTheme,
-  ThemeProvider,
-} from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
+  ThemeProvider
+} from "@material-ui/core/styles";
+import CssBaseline from "@material-ui/core/CssBaseline";
 
-import ConnectCard from './ConnectCard';
-import DeployCard from './DeployCard';
-import MaterialCard from './MaterialCard';
-import ThemeCard from './ThemeCard';
-import UploadCard from './UploadCard';
+import ConnectCard from "./ConnectCard";
+import DeployCard from "./DeployCard";
+import MaterialCard from "./MaterialCard";
+import ThemeCard from "./ThemeCard";
+import UploadCard from "./UploadCard";
 
-import logo from '../assets/images/logo.png';
+import logo from "../assets/images/logo.png";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   container: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: '30px',
-    width: 'calc(100% - 16px)',
-    marginLeft: '8px',
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+
+    padding: "30px",
+    width: "calc(100% - 16px)",
+    marginLeft: "8px"
   },
   card: {
-    height: '700px',
-    padding: '10px 25px',
-    overflow: 'auto',
+    height: "700px",
+    padding: "10px 25px",
+    overflow: "auto"
   },
   cardHeader: {
-    marginBottom: '30px',
+    marginBottom: "30px"
   },
   img: {
-    width: '210px',
-    background: 'white',
-    padding: '0 10px',
-    height: '100%',
-    margin: '0 20px',
+    width: "210px",
+    background: "white",
+    height: "100%",
+    paddingRight: "20px"
   },
   box: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    [theme.breakpoints.down('sm')]: {
-      flexDirection: 'column',
-      textAlign: 'center',
-    },
+    flexDirection: "row",
+    alignItems: "center",
+    [theme.breakpoints.down("sm")]: {
+      flexDirection: "column",
+      textAlign: "center"
+    }
   },
   gridContainer: {
     marginTop: 20,
-    display: 'flex',
-    flexWrap: 'wrap',
-    width: 500,
+    display: "flex",
+    flexWrap: "wrap",
+    width: 500
   },
   form: {
-    marginTop: '50',
+    marginTop: "50"
   },
   response: {
-    fontFamily: 'monospace',
-    color: 'limeGreen',
-    fontSize: '1.3em',
-    background: 'black',
-    padding: '0px 5px',
+    fontFamily: "monospace",
+    color: "limeGreen",
+    fontSize: "1.3em",
+    background: "black",
+    padding: "0px 5px"
   },
   list: {
-    fontSize: '1.1em',
-    '& li': {
-      marginBottom: '8px',
-    },
+    fontSize: "1.1em",
+    "& li": {
+      marginBottom: "8px"
+    }
   },
   contained: {
-    color: 'white',
-    fontWeight: '600',
-    background: '#787878',
-    '&:hover': {
-      background: '#888',
+    color: "white",
+    fontWeight: "600",
+    background: "#787878",
+    "&:hover": {
+      background: "#888"
     },
     borderRadius: 5,
-    margin: '15px 0px',
+    margin: "15px 0px"
   },
   pre: {
-    whiteSpace: 'pre-wrap',
+    whiteSpace: "pre-wrap"
   },
   link: {
-    color: '#35baf6',
-  },
+    color: "#35baf6"
+  }
 }));
 
 function App() {
@@ -93,76 +93,61 @@ function App() {
 
   const theme = createMuiTheme({
     palette: {
-      type: 'dark',
-    },
+      type: "light"
+    }
   });
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Box>
-        <Box className={classes.box} display="flex">
-          <Box
-            mt="20px"
-            display="flex"
-            flexDirection="column"
-            alignItems="center"
-          >
-            <img className={classes.img} src={logo} alt="Shipyard logo" />
-            <Typography variant="caption">
-              Replace this with your logo:
-            </Typography>
-            <Typography variant="caption">
-              <code>'/frontend/src/assets/images/logo.png'</code>{' '}
-            </Typography>
-          </Box>
-          <Box mt={-2}>
-            <h1>
-              <Link
-                className={classes.link}
-                target="_blank"
-                rel="noopener"
-                href="https://github.com/facebook/react"
-              >
-                React
-              </Link>
-              -
-              <Link
-                className={classes.link}
-                target="_blank"
-                rel="noopener"
-                href="https://github.com/pallets/flask"
-              >
-                Flask
-              </Link>
-              -
-              <Link
-                className={classes.link}
-                target="_blank"
-                rel="noopener"
-                href="https://github.com/postgres/postgres"
-              >
-                Postgres
-              </Link>
-              -
-              <Link
-                className={classes.link}
-                target="_blank"
-                rel="noopener"
-                href="https://github.com/localstack/localstack"
-              >
-                LocalStack
-              </Link>{' '}
-              Starter Project
-            </h1>
-          </Box>
-        </Box>
         <Grid container className={classes.container} spacing={2}>
-          <Grid item xs={12} sm={12} md={6} lg={4}>
-            <ThemeCard classes={classes} />
-          </Grid>
-          <Grid item xs={12} sm={12} md={6} lg={4}>
-            <MaterialCard classes={classes} />
+          <Grid item xs={12} sm={12} md={12} lg={12}>
+            <Box className={classes.box} display="flex" alignItems="center">
+              <Box display="flex" flexDirection="column" alignItems="center">
+                <img className={classes.img} src={logo} alt="Shipyard logo" />
+              </Box>
+              <Box alignItems="center" display="flex" justifyContent="center">
+                <h1 style={{ marginTop: 0, marginBottom: 0 }}>
+                  <Link
+                    className={classes.link}
+                    target="_blank"
+                    rel="noopener"
+                    href="https://github.com/facebook/react"
+                  >
+                    React
+                  </Link>
+                  -
+                  <Link
+                    className={classes.link}
+                    target="_blank"
+                    rel="noopener"
+                    href="https://github.com/pallets/flask"
+                  >
+                    Flask
+                  </Link>
+                  -
+                  <Link
+                    className={classes.link}
+                    target="_blank"
+                    rel="noopener"
+                    href="https://github.com/postgres/postgres"
+                  >
+                    Postgres
+                  </Link>
+                  -
+                  <Link
+                    className={classes.link}
+                    target="_blank"
+                    rel="noopener"
+                    href="https://github.com/localstack/localstack"
+                  >
+                    LocalStack
+                  </Link>{" "}
+                  Starter Project
+                </h1>
+              </Box>
+            </Box>
           </Grid>
           <Grid item xs={12} sm={12} md={6} lg={4}>
             <ConnectCard classes={classes} />
@@ -172,6 +157,12 @@ function App() {
           </Grid>
           <Grid item xs={12} sm={12} md={6} lg={4}>
             <DeployCard classes={classes} />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={4}>
+            <ThemeCard classes={classes} />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={4}>
+            <MaterialCard classes={classes} />
           </Grid>
         </Grid>
       </Box>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -105,7 +105,12 @@ function App() {
           <Grid item xs={12} sm={12} md={12} lg={12}>
             <Box className={classes.box} display="flex" alignItems="center">
               <Box display="flex" flexDirection="column" alignItems="center">
-                <img className={classes.img} src={logo} alt="Shipyard logo" />
+                <img
+                  className={classes.img}
+                  src={logo}
+                  alt="Shipyard logo"
+                  id="page-logo"
+                />
               </Box>
               <Box alignItems="center" display="flex" justifyContent="center">
                 <h1 style={{ marginTop: 0, marginBottom: 0 }}>

--- a/frontend/src/components/ConnectCard.js
+++ b/frontend/src/components/ConnectCard.js
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
-import { Box, Button, Card, Link } from '@material-ui/core';
-import Prism from 'prismjs';
+import { useEffect, useState } from "react";
+import { Box, Button, Card, Link } from "@material-ui/core";
+import Prism from "prismjs";
 
-import flaskLogo from '../assets/images/flask.png';
+import flaskLogo from "../assets/images/flask.png";
 
 function ResponseBlock(props) {
   useEffect(() => {
@@ -22,14 +22,14 @@ function ConnectCard(props) {
   const { classes } = props;
 
   const fetchData = () => {
-    fetch('/api/v1/')
-      .then((res) => res.json())
+    fetch("/api/v1/")
+      .then(res => res.json())
       .then(
-        (result) => {
+        result => {
           setIsLoaded(true);
           setData(result);
         },
-        (error) => {
+        error => {
           setIsLoaded(true);
           setError(error);
         }
@@ -37,9 +37,9 @@ function ConnectCard(props) {
   };
 
   const resetCounter = () => {
-    fetch('/api/v1/reset/')
-      .then((res) => res.json())
-      .then((data) => fetchData());
+    fetch("/api/v1/reset/")
+      .then(res => res.json())
+      .then(data => fetchData());
   };
 
   useEffect(() => fetchData(), []);
@@ -57,36 +57,45 @@ function ConnectCard(props) {
   } else
     return (
       <Card className={classes.card}>
-        <h2>Connect to a server</h2>
-        <Box
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          mt={-3}
-          mb={-1}
+        <div
+          style={{
+            fontSize: "48px",
+            fontWeight: "bold",
+            marginTop: "9px",
+            lineHeight: "72px"
+          }}
         >
-          <Box mr={1}>
-            <h3>Powered by</h3>
-          </Box>
-          <img width="75px" height="100%" src={flaskLogo} alt="Flask Logo" />
-        </Box>
+          API Call Count
+        </div>
+        <div
+          id="api-call-counter"
+          style={{
+            fontSize: "48px",
+            fontWeight: "bold",
+            lineHeight: "72px",
+            border: "1px solid hsl(199, 91%, 59%)",
+            borderRadius: "4px",
+            padding: "0.3em 0.5em 0.15em",
+            backgroundColor: "hsla(199, 91%, 59%, 0.05)"
+          }}
+        >
+          {data.response}
+        </div>
+
         <p>
-          This React frontend is connected to a Flask server. Below is the
+          This React frontend is connected to a Flask server. Above is the
           response message we receive when we ping the server:
         </p>
 
-        <pre className={classes.pre}>
-          <p className={classes.response}>
-            {'>'} {data.response}
-          </p>
-        </pre>
+        <p>Flask server running on port 8080.</p>
 
         <p>
-          The server ping count is stored to the database. Click below to{' '}
+          The server ping count is stored to the database. Click below to{" "}
           <b>reset the counter:</b>
         </p>
         <Box display="flex" justifyContent="center">
           <Button
+            id="api-call-reset-button"
             variant="contained"
             size="small"
             className={classes.contained}
@@ -95,19 +104,6 @@ function ConnectCard(props) {
             Reset Counter
           </Button>
         </Box>
-        <p>
-          The <b>endpoint</b> that resets the ping counter is located in{' '}
-          <code>
-            <Link
-              className={classes.link}
-              href={`${process.env.REACT_APP_STARTER_REPO_URL}backend/src/routes/counter.py#L23-L27`}
-              target="_blank"
-            >
-              backend/src/routes/counter.py
-            </Link>
-          </code>
-          :
-        </p>
         <ResponseBlock language="language-js" code={codeBlock} />
       </Card>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-flask-starter",
+  "name": "risa-react-flask-cypress-starter",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
- visual cleanup to make the visitor counter stand out more
- use id attributes on the html tags we're testing against so the selectors are more reliable
- add depends_on to the services in docker compose so that they're waiting on each other when starting
- reorder the info boxes on the page so that the most important ones are first

To test:
- Check that the services deploy correctly on Shipyard
- Check that the cypress github action passes (seems github checks aren't enabled on this repo in the shipyard settings)